### PR TITLE
Must require stringio in newer ruby

### DIFF
--- a/ruby/import_tf.rb
+++ b/ruby/import_tf.rb
@@ -6,6 +6,7 @@
 #
 # DESCRIPTION: Cadence techfile import for KLayout - core functionality.
 #
+require 'stringio'
 
 module TechfileToKLayout
 


### PR DESCRIPTION
Using ruby 2.7, I had to add the require statement or I got an error:

> ERROR: /home/X/.klayout/ruby/import_tf.rb:71: uninitialized constant TechfileToKLayout::StringIO
  /home/X/.klayout/ruby/import_tf.rb:71:in `read_skill_file_as_ruby_expr'
  /home/X/.klayout/ruby/import_tf.rb:196:in `import_techfile'
  /home/X/.klayout/macros/import_tf_standalone.rb:35:in `<module:TechfileToKLayout>'
  /home/X/.klayout/macros/import_tf_standalone.rb:24:in `<main>' (class NameError)